### PR TITLE
Kayukawa/category for expo2025

### DIFF
--- a/QueryService/src/org/hulop/data/Directory.java
+++ b/QueryService/src/org/hulop/data/Directory.java
@@ -445,7 +445,6 @@ public class Directory implements Searchable, Cloneable {
 		String keyConfigUrlString = String.format("http://%s/cabot/query_service_keys.json", host);
 		URL featuresUrl = new URL(featuresUrlstr);
 		URL nodemapUrl = new URL(nodemapUrlString);
-		URL keyConfigUrl = new URL(keyConfigUrlString);
 		Directory d = new Directory(featuresUrl, nodemapUrl, new Locale(lang), enableGroupBuilding, enableGroupFloor, enableGroupCategory, enableGroupNearbyFacility);
 		walk(d.toJSON(), 0, 5);
 	}

--- a/QueryService/src/org/hulop/data/Directory.java
+++ b/QueryService/src/org/hulop/data/Directory.java
@@ -27,7 +27,6 @@ public class Directory implements Searchable, Cloneable {
 	}
 	
 	public Directory(URL featuresUrl, URL nodemapUrl, Locale locale, boolean groupBuilding, boolean groupFloor, boolean groupCategory, boolean groupNearbyFacility) {
-
 		MapGeojson features = null;
 		MapGeojson nodemap = null;
 		try {

--- a/QueryService/src/org/hulop/data/Directory.java
+++ b/QueryService/src/org/hulop/data/Directory.java
@@ -26,7 +26,7 @@ public class Directory implements Searchable, Cloneable {
 		// TODO Auto-generated constructor stub
 	}
 	
-	public Directory(URL featuresUrl, URL nodemapUrl, Locale locale, boolean groupBuilding, boolean groupFloor, boolean groupCategory, boolean groupNearbyFacility) {
+	public Directory(URL featuresUrl, URL nodemapUrl, URL keyConfigUrl, Locale locale, boolean groupBuilding, boolean groupFloor, boolean groupCategory, boolean groupNearbyFacility) {
 		MapGeojson features = null;
 		MapGeojson nodemap = null;
 		try {
@@ -121,10 +121,10 @@ public class Directory implements Searchable, Cloneable {
 			for(String category:features.getMajorCategories()) {
 				if (category == null || category.isEmpty()) continue;
 				List<Facility> facilities = features.getFacilitiesByMajorCategory(category);
-				Item i = categoriesSection.add(new Item(Messages.get(locale, category), null));
+				Item i = categoriesSection.add(new Item(Messages.get(locale, keyConfigUrl, category), null));
 
 				Directory categoryDirectory = i.setContent(new Directory());
-				Section categorySection = categoryDirectory.add(new Section(Messages.get(locale, category)));
+				Section categorySection = categoryDirectory.add(new Section(Messages.get(locale, keyConfigUrl, category)));
 				for(Facility f:facilities) {
 					try {
 						categorySection.add(new Item(f.getName(),
@@ -442,9 +442,11 @@ public class Directory implements Searchable, Cloneable {
 		Boolean enableGroupNearbyFacility = false;
 		String featuresUrlstr = String.format("http://%s/routesearch?action=start&cache=false&lat=%s&lng=%s&user=%s&dist=%s&lang=%s", host, lat, lng, user, dist, lang);
 		String nodemapUrlString = String.format("http://%s/routesearch?action=nodemap&cache=false&lat=%s&lng=%s&user=%s&dist=%s&lang=%s", host, lat, lng, user, dist, lang);
+		String keyConfigUrlString = String.format("http://%s/cabot/query_service_keys.json", host);
 		URL featuresUrl = new URL(featuresUrlstr);
 		URL nodemapUrl = new URL(nodemapUrlString);
-		Directory d = new Directory(featuresUrl, nodemapUrl, new Locale(lang), enableGroupBuilding, enableGroupFloor, enableGroupCategory, enableGroupNearbyFacility);
+		URL keyConfigUrl = new URL(keyConfigUrlString);
+		Directory d = new Directory(featuresUrl, nodemapUrl, keyConfigUrl, new Locale(lang), enableGroupBuilding, enableGroupFloor, enableGroupCategory, enableGroupNearbyFacility);
 		walk(d.toJSON(), 0, 5);
 	}
 	// utility function

--- a/QueryService/src/org/hulop/data/Directory.java
+++ b/QueryService/src/org/hulop/data/Directory.java
@@ -22,20 +22,6 @@ public class Directory implements Searchable, Cloneable {
 	public Boolean showSectionIndex = false;
 	private JSONArray landmarks;
 
-	private static final URL keyConfigUrl = initKeyConfigUrl();
-	private static URL initKeyConfigUrl() {
-		try {
-			String use_http = System.getenv("HULOP_MAP_SERVICE_USE_HTTP");
-			String protocol = ("true".equals(use_http)) ? "http" : "https";
-			String mapService = System.getenv("HULOP_MAP_SERVICE");
-			String keyConfigUrlString = String.format("%s://%s/cabot/query_service_keys.json", protocol, mapService);
-			return new URL(keyConfigUrlString);
-		} catch (Exception e) {
-			e.printStackTrace();
-			return null;
-		}
-	}
-
 	public Directory() {
 		// TODO Auto-generated constructor stub
 	}
@@ -136,10 +122,10 @@ public class Directory implements Searchable, Cloneable {
 			for(String category:features.getMajorCategories()) {
 				if (category == null || category.isEmpty()) continue;
 				List<Facility> facilities = features.getFacilitiesByMajorCategory(category);
-				Item i = categoriesSection.add(new Item(Messages.get(locale, keyConfigUrl, category), null));
+				Item i = categoriesSection.add(new Item(Messages.get(locale, category), null));
 
 				Directory categoryDirectory = i.setContent(new Directory());
-				Section categorySection = categoryDirectory.add(new Section(Messages.get(locale, keyConfigUrl, category)));
+				Section categorySection = categoryDirectory.add(new Section(Messages.get(locale, category)));
 				for(Facility f:facilities) {
 					try {
 						categorySection.add(new Item(f.getName(),

--- a/QueryService/src/org/hulop/data/Directory.java
+++ b/QueryService/src/org/hulop/data/Directory.java
@@ -22,11 +22,26 @@ public class Directory implements Searchable, Cloneable {
 	public Boolean showSectionIndex = false;
 	private JSONArray landmarks;
 
+	private static final URL keyConfigUrl = initKeyConfigUrl();
+	private static URL initKeyConfigUrl() {
+		try {
+			String use_http = System.getenv("HULOP_MAP_SERVICE_USE_HTTP");
+			String protocol = ("true".equals(use_http)) ? "http" : "https";
+			String mapService = System.getenv("HULOP_MAP_SERVICE");
+			String keyConfigUrlString = String.format("%s://%s/cabot/query_service_keys.json", protocol, mapService);
+			return new URL(keyConfigUrlString);
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
 	public Directory() {
 		// TODO Auto-generated constructor stub
 	}
 	
-	public Directory(URL featuresUrl, URL nodemapUrl, URL keyConfigUrl, Locale locale, boolean groupBuilding, boolean groupFloor, boolean groupCategory, boolean groupNearbyFacility) {
+	public Directory(URL featuresUrl, URL nodemapUrl, Locale locale, boolean groupBuilding, boolean groupFloor, boolean groupCategory, boolean groupNearbyFacility) {
+
 		MapGeojson features = null;
 		MapGeojson nodemap = null;
 		try {
@@ -446,7 +461,7 @@ public class Directory implements Searchable, Cloneable {
 		URL featuresUrl = new URL(featuresUrlstr);
 		URL nodemapUrl = new URL(nodemapUrlString);
 		URL keyConfigUrl = new URL(keyConfigUrlString);
-		Directory d = new Directory(featuresUrl, nodemapUrl, keyConfigUrl, new Locale(lang), enableGroupBuilding, enableGroupFloor, enableGroupCategory, enableGroupNearbyFacility);
+		Directory d = new Directory(featuresUrl, nodemapUrl, new Locale(lang), enableGroupBuilding, enableGroupFloor, enableGroupCategory, enableGroupNearbyFacility);
 		walk(d.toJSON(), 0, 5);
 	}
 	// utility function

--- a/QueryService/src/org/hulop/data/i18n/Messages.java
+++ b/QueryService/src/org/hulop/data/i18n/Messages.java
@@ -1,17 +1,28 @@
 package org.hulop.data.i18n;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.ResourceBundle;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.wink.json4j.JSONObject;
 
 public class Messages {
+	private static final String REMOTE_URL = "http://localhost:9090/map/cabot/query_service_keys.json";
+    private static final long CACHE_EXPIRY = 60000;
+    private static Map<String, Map<String, String>> remoteTranslations = new ConcurrentHashMap<>();
+    private static long lastFetchedTime = 0;
 
 	private static ResourceBundle.Control control = new ResourceBundle.Control() {
 		public static final String XML = "xml";
@@ -75,14 +86,72 @@ public class Messages {
 	}
 	
 	public static String get(Locale locale, String key) {
+		String remoteValue = getFromRemote(locale, key);
+		if (!remoteValue.startsWith("___")) {
+			return remoteValue;
+		}
+
 		ResourceBundle resource = getBundle(locale);
 		if (resource != null) {
 			try {
 				return resource.getString(key);
 			} catch (Exception e) {
-				return "___"+key+"___no_entry";
+				return "___" + key + "___no_entry";
 			}
 		}
-		return "___"+key+"___no_resource";
-	}	
+		return "___" + key + "___no_resource";
+	}
+
+	private static String getFromRemote(Locale locale, String key) {
+        if (System.currentTimeMillis() - lastFetchedTime > CACHE_EXPIRY) {
+            fetchRemoteTranslations();
+        }
+
+        Map<String, String> translations = remoteTranslations.get(key);
+        if (translations != null) {
+            return translations.getOrDefault(locale.getLanguage(), "___" + key + "___no_entry");
+        }
+        return "___" + key + "___no_entry";
+    }
+
+	private static void fetchRemoteTranslations() {
+        try {
+            URL url = new URL(REMOTE_URL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Accept", "application/json");
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(5000);
+
+            if (conn.getResponseCode() == 200) {
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+                    StringBuilder response = new StringBuilder();
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        response.append(line);
+                    }
+
+                    JSONObject jsonObject = new JSONObject(response.toString());
+                    JSONObject queryServiceKeys = jsonObject.getJSONObject("query_service_keys");
+
+                    remoteTranslations.clear();
+                    for (Object keyObj : queryServiceKeys.keySet()) {
+						String key = keyObj.toString();
+                        JSONObject value = queryServiceKeys.getJSONObject(key);
+
+                        Map<String, String> translations = new ConcurrentHashMap<>();
+                        for (Object langKeyObj : value.keySet()) {
+							String langKey = langKeyObj.toString();
+                            translations.put(langKey, value.getString(langKey));
+                        }
+                        remoteTranslations.put(key, translations);
+                    }
+                    lastFetchedTime = System.currentTimeMillis();
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
 }

--- a/QueryService/src/org/hulop/data/i18n/Messages.java
+++ b/QueryService/src/org/hulop/data/i18n/Messages.java
@@ -19,10 +19,23 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.wink.json4j.JSONObject;
 
 public class Messages {
-	private static final String REMOTE_URL = "http://localhost:9090/map/cabot/query_service_keys.json";
 	private static final long CACHE_EXPIRY = 60000;
 	private static Map<String, Map<String, String>> remoteTranslations = new ConcurrentHashMap<>();
 	private static long lastFetchedTime = 0;
+
+	private static final URL keyConfigUrl = initKeyConfigUrl();
+	private static URL initKeyConfigUrl() {
+		try {
+			String use_http = System.getenv("HULOP_MAP_SERVICE_USE_HTTP");
+			String protocol = ("true".equals(use_http)) ? "http" : "https";
+			String mapService = System.getenv("HULOP_MAP_SERVICE");
+			String keyConfigUrlString = String.format("%s://%s/map/hulop_messages.json", protocol, mapService);
+			return new URL(keyConfigUrlString);
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
 
 	private static ResourceBundle.Control control = new ResourceBundle.Control() {
 		public static final String XML = "xml";
@@ -84,21 +97,9 @@ public class Messages {
 	public static ResourceBundle getBundle(Locale locale) {
 		return ResourceBundle.getBundle("org.hulop.data.i18n.Messages", locale, control);
 	}
-
-	public static String get(Locale locale, String key) {
-		ResourceBundle resource = getBundle(locale);
-		if (resource != null) {
-			try {
-				return resource.getString(key);
-			} catch (Exception e) {
-				return "___"+key+"___no_entry";
-			}
-		}
-		return "___"+key+"___no_resource";
-	}
 	
-	public static String get(Locale locale, URL keyConfigUrl, String key) {
-		String remoteValue = getFromRemote(locale, keyConfigUrl, key);
+	public static String get(Locale locale, String key) {
+		String remoteValue = getFromRemote(locale, key);
 		if (!remoteValue.startsWith("___")) {
 			return remoteValue;
 		}
@@ -114,7 +115,7 @@ public class Messages {
 		return "___" + key + "___no_resource";
 	}
 
-	private static String getFromRemote(Locale locale, URL keyConfigUrl, String key) {
+	private static String getFromRemote(Locale locale, String key) {
         if (System.currentTimeMillis() - lastFetchedTime > CACHE_EXPIRY) {
             fetchRemoteTranslations(keyConfigUrl);
         }

--- a/QueryService/src/org/hulop/data/i18n/Messages.java
+++ b/QueryService/src/org/hulop/data/i18n/Messages.java
@@ -99,9 +99,8 @@ public class Messages {
 	}
 	
 	public static String get(Locale locale, String key) {
-		String remoteValue = getFromRemote(locale, key);
-		if (!remoteValue.startsWith("___")) {
-			return remoteValue;
+		if (isRemoteKeyPresent(locale, key)) {
+			return getFromRemote(locale, key);
 		}
 
 		ResourceBundle resource = getBundle(locale);
@@ -115,19 +114,21 @@ public class Messages {
 		return "___" + key + "___no_resource";
 	}
 
+	private static boolean isRemoteKeyPresent(Locale locale, String key) {
+		if (System.currentTimeMillis() - lastFetchedTime > CACHE_EXPIRY) {
+			fetchRemoteTranslations();
+		}
+	
+		Map<String, String> translations = remoteTranslations.get(key);
+		return translations != null && translations.containsKey(locale.getLanguage());
+	}
+
 	private static String getFromRemote(Locale locale, String key) {
-        if (System.currentTimeMillis() - lastFetchedTime > CACHE_EXPIRY) {
-            fetchRemoteTranslations(keyConfigUrl);
-        }
+		Map<String, String> translations = remoteTranslations.get(key);
+		return translations.get(locale.getLanguage());
+	}
 
-        Map<String, String> translations = remoteTranslations.get(key);
-        if (translations != null) {
-            return translations.getOrDefault(locale.getLanguage(), "___" + key + "___no_entry");
-        }
-        return "___" + key + "___no_entry";
-    }
-
-	private static void fetchRemoteTranslations(URL keyConfigUrl) {
+	private static void fetchRemoteTranslations() {
         try {
             HttpURLConnection conn = (HttpURLConnection) keyConfigUrl.openConnection();
             conn.setRequestMethod("GET");

--- a/QueryService/src/org/hulop/data/i18n/Messages.java
+++ b/QueryService/src/org/hulop/data/i18n/Messages.java
@@ -20,9 +20,9 @@ import org.apache.wink.json4j.JSONObject;
 
 public class Messages {
 	private static final String REMOTE_URL = "http://localhost:9090/map/cabot/query_service_keys.json";
-    private static final long CACHE_EXPIRY = 60000;
-    private static Map<String, Map<String, String>> remoteTranslations = new ConcurrentHashMap<>();
-    private static long lastFetchedTime = 0;
+	private static final long CACHE_EXPIRY = 60000;
+	private static Map<String, Map<String, String>> remoteTranslations = new ConcurrentHashMap<>();
+	private static long lastFetchedTime = 0;
 
 	private static ResourceBundle.Control control = new ResourceBundle.Control() {
 		public static final String XML = "xml";

--- a/QueryService/src/org/hulop/data/i18n/Messages.java
+++ b/QueryService/src/org/hulop/data/i18n/Messages.java
@@ -118,7 +118,7 @@ public class Messages {
 		if (System.currentTimeMillis() - lastFetchedTime > CACHE_EXPIRY) {
 			fetchRemoteTranslations();
 		}
-	
+
 		Map<String, String> translations = remoteTranslations.get(key);
 		return translations != null && translations.containsKey(locale.getLanguage());
 	}

--- a/QueryService/src/org/hulop/data/i18n/Messages.java
+++ b/QueryService/src/org/hulop/data/i18n/Messages.java
@@ -84,9 +84,21 @@ public class Messages {
 	public static ResourceBundle getBundle(Locale locale) {
 		return ResourceBundle.getBundle("org.hulop.data.i18n.Messages", locale, control);
 	}
-	
+
 	public static String get(Locale locale, String key) {
-		String remoteValue = getFromRemote(locale, key);
+		ResourceBundle resource = getBundle(locale);
+		if (resource != null) {
+			try {
+				return resource.getString(key);
+			} catch (Exception e) {
+				return "___"+key+"___no_entry";
+			}
+		}
+		return "___"+key+"___no_resource";
+	}
+	
+	public static String get(Locale locale, URL keyConfigUrl, String key) {
+		String remoteValue = getFromRemote(locale, keyConfigUrl, key);
 		if (!remoteValue.startsWith("___")) {
 			return remoteValue;
 		}
@@ -102,9 +114,9 @@ public class Messages {
 		return "___" + key + "___no_resource";
 	}
 
-	private static String getFromRemote(Locale locale, String key) {
+	private static String getFromRemote(Locale locale, URL keyConfigUrl, String key) {
         if (System.currentTimeMillis() - lastFetchedTime > CACHE_EXPIRY) {
-            fetchRemoteTranslations();
+            fetchRemoteTranslations(keyConfigUrl);
         }
 
         Map<String, String> translations = remoteTranslations.get(key);
@@ -114,10 +126,9 @@ public class Messages {
         return "___" + key + "___no_entry";
     }
 
-	private static void fetchRemoteTranslations() {
+	private static void fetchRemoteTranslations(URL keyConfigUrl) {
         try {
-            URL url = new URL(REMOTE_URL);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            HttpURLConnection conn = (HttpURLConnection) keyConfigUrl.openConnection();
             conn.setRequestMethod("GET");
             conn.setRequestProperty("Accept", "application/json");
             conn.setConnectTimeout(5000);

--- a/QueryService/src/org/hulop/data/i18n/Messages_en.xml
+++ b/QueryService/src/org/hulop/data/i18n/Messages_en.xml
@@ -4,8 +4,6 @@
 <entry key="buildings">Search by Building</entry>
 <entry key="categories">Search by Category</entry>
 <entry key="demonstration">for Demonstration/Test</entry>
-<entry key="Domestic_Pavilion">Domestic Pavilions</entry>
-<entry key="Signature_Pavilion">Signature Pavilions</entry>
 <entry key="floors">Search by Floor</entry>
 <entry key="floor_above_ground">{0}F</entry>
 <entry key="floor_below_ground">B{0}F</entry>

--- a/QueryService/src/org/hulop/data/i18n/Messages_ja.xml
+++ b/QueryService/src/org/hulop/data/i18n/Messages_ja.xml
@@ -8,8 +8,6 @@
 <entry key="outdoor">屋外</entry>
 <entry key="categories">カテゴリーから検索</entry>
 <entry key="demonstration">デモ・テスト用</entry>
-<entry key="Domestic_Pavilion">国内パビリオン</entry>
-<entry key="Signature_Pavilion">シグネチャーパビリオン</entry>
 <entry key="people">名前から検索</entry>
 <entry key="list_of_people">名前の一覧</entry>
 <entry key="male_restroom">男性用トイレ</entry>

--- a/QueryService/src/org/hulop/servlet/DirectoryServlet.java
+++ b/QueryService/src/org/hulop/servlet/DirectoryServlet.java
@@ -59,6 +59,7 @@ public class DirectoryServlet extends HttpServlet {
 		String protocol = ("true".equals(use_http)) ? "http" : "https";
 		String mapService = System.getenv("HULOP_MAP_SERVICE");
 		String baseUrlString = String.format("%s://%s/routesearch", protocol, mapService);
+		String keyConfigUrlString = String.format("%s://%s/cabot/query_service_keys.json", protocol, mapService);
 		String enableGroupBuildingString = System.getenv("SEARCH_BY_BUILDING_ENABLED");
 		boolean enableGroupBuilding = enableGroupBuildingString != null ? Boolean.parseBoolean(enableGroupBuildingString) : false;
 		String enableGroupFloorString = System.getenv("SEARCH_BY_FLOOR_ENABLED");
@@ -89,7 +90,8 @@ public class DirectoryServlet extends HttpServlet {
 		try {
 			URL featuresUrl = new URL(featuresUrlString);
 			URL nodemapUrl  = new URL(nodemapUrlString);
-			Directory cdd = new Directory(featuresUrl, nodemapUrl, new Locale(lang), enableGroupBuilding, enableGroupFloor, enableGroupCategory, enableGroupNearbyFacility);
+			URL keyConfigUrl = new URL(keyConfigUrlString);
+			Directory cdd = new Directory(featuresUrl, nodemapUrl, keyConfigUrl, new Locale(lang), enableGroupBuilding, enableGroupFloor, enableGroupCategory, enableGroupNearbyFacility);
 			bean.addSearchable(user, cdd);
 			sendJSON(cdd.toJSON(), request, response);
 		}catch (Exception e) {

--- a/QueryService/src/org/hulop/servlet/DirectoryServlet.java
+++ b/QueryService/src/org/hulop/servlet/DirectoryServlet.java
@@ -59,7 +59,6 @@ public class DirectoryServlet extends HttpServlet {
 		String protocol = ("true".equals(use_http)) ? "http" : "https";
 		String mapService = System.getenv("HULOP_MAP_SERVICE");
 		String baseUrlString = String.format("%s://%s/routesearch", protocol, mapService);
-		String keyConfigUrlString = String.format("%s://%s/cabot/query_service_keys.json", protocol, mapService);
 		String enableGroupBuildingString = System.getenv("SEARCH_BY_BUILDING_ENABLED");
 		boolean enableGroupBuilding = enableGroupBuildingString != null ? Boolean.parseBoolean(enableGroupBuildingString) : false;
 		String enableGroupFloorString = System.getenv("SEARCH_BY_FLOOR_ENABLED");
@@ -90,8 +89,7 @@ public class DirectoryServlet extends HttpServlet {
 		try {
 			URL featuresUrl = new URL(featuresUrlString);
 			URL nodemapUrl  = new URL(nodemapUrlString);
-			URL keyConfigUrl = new URL(keyConfigUrlString);
-			Directory cdd = new Directory(featuresUrl, nodemapUrl, keyConfigUrl, new Locale(lang), enableGroupBuilding, enableGroupFloor, enableGroupCategory, enableGroupNearbyFacility);
+			Directory cdd = new Directory(featuresUrl, nodemapUrl, new Locale(lang), enableGroupBuilding, enableGroupFloor, enableGroupCategory, enableGroupNearbyFacility);
 			bean.addSearchable(user, cdd);
 			sendJSON(cdd.toJSON(), request, response);
 		}catch (Exception e) {


### PR DESCRIPTION
Enabled fetching  cabot_sites_xx-specific keys (e.g., Signature Zone) from a JSON file on the MapServer.

Example JSON file ([`server_data/attachments/cabot/query_service_keys.json`](https://github.com/CMU-cabot/cabot_sites_expo2025/blob/kayukawa/tour_draft/cabot_site_expo2025_3d/server_data/attachments/cabot/query_service_keys.json)):
```jsx
{
    "query_service_keys": {
        "Signature_Zone": {
            "en": "Signature Zone",
            "ja": "シグネチャーゾーン"
        },
        "Empowering_Zone": {
            "en": "Empowering Zone",
            "ja": "エンパワーリングゾーン"
        },
        "Connecting_Zone": {
            "en": "Connecting Zone",
            "ja": "コネクティングゾーン"
        },
        "Saving_Zone": {
            "en": "Saving Zone",
            "ja": "セービングゾーン"
        },
        "Future_Life_Zone": {
            "en": "Future Life Zone",
            "ja": "フューチャーライフゾーン"
        },
        "East_Gate_Zone": {
            "en": "Empowering Zone",
            "ja": "東ゲートゾーン"
        },
        "West_Gate_Zone": {
            "en": "Empowering Zone",
            "ja": "西ゲートゾーン"
        }
    }
}
```